### PR TITLE
drone.ioをGithubActionsへ移行・書き換えする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
 
       - run: go test -v ./...
 
-      - run: go run main.go
+      - run: go run ./main.go
 
       - run: go build
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,0 @@
-notify:
-  slack:
-    webhook_url: $$SLACK_URL
-    channel: dev
-    username: drone

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  ci:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        golang: [1.19.4]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Golang env
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.golang }}
+
+      - name: Get lib
+        run: go get
+
+      - name: Run tests
+        run: go test -v ./...
+
+      - name: Run main module
+        run: go run ./main.go
+
+      - name: Run build
+        run: go build
+
+      - name: Notify Discord
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook:
+            ${{ secrets.DISCORD_WEBHOOK_URL }}
+        if: failure()

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ GO言語で三浦が「初めて作った」プログラム兼実験場です。
 
 ## Latest integration
 
-+ master : [![Build Status](https://drone.io/github.com/kazuhito-m/go-first-project/status.png?)](https://drone.io/github.com/kazuhito-m/go-first-project/latest) by Drone IO
++ master : [![ci](https://github.com/kazuhito-m/go-first-project/actions/workflows/ci.yml/badge.svg)](https://github.com/kazuhito-m/go-first-project/actions/workflows/ci.yml) by Github Actions
 + master : [![Circle CI](https://circleci.com/gh/kazuhito-m/go-first-project.svg?style=svg)](https://circleci.com/gh/kazuhito-m/go-first-project) by Circle CI
 
 ## author


### PR DESCRIPTION
もう遠の昔に drone.io サービスが停止したので、そのCIを GithubActions に移植し、元のファイルは消す。
